### PR TITLE
Remove test library dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/kalafut/imohash
 
-require (
-	github.com/twmb/murmur3 v1.1.5
-	gopkg.in/tylerb/is.v1 v1.1.2
-)
+go 1.11
+
+require github.com/twmb/murmur3 v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/twmb/murmur3 v1.1.5 h1:i9OLS9fkuLzBXjt6dptlAEyk58fJsSTXbRg3SgVyqgk=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
-gopkg.in/tylerb/is.v1 v1.1.2 h1:AB/MANFml2ySf+adwcinvajyHvsYltAOD+rb/8njfSU=
-gopkg.in/tylerb/is.v1 v1.1.2/go.mod h1:9yQB2tyIhZ5oph6Kk5Sq7cJMd9c5Jpa1p3hr9kxzPqo=

--- a/imohash_test.go
+++ b/imohash_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
 	"testing"
-
-	"gopkg.in/tylerb/is.v1"
 )
 
 var tempDir string
@@ -17,7 +17,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	// Make a temp area for test files
-	tempDir, _ = ioutil.TempDir(os.TempDir(), "imohash_test_data")
+	tempDir, _ = os.MkdirTemp(os.TempDir(), "imohash_test_data")
 	ret := m.Run()
 	os.RemoveAll(tempDir)
 	os.Exit(ret)
@@ -28,89 +28,87 @@ func TestCustom(t *testing.T) {
 	var hash [Size]byte
 	var err error
 
-	is := is.New(t)
-
 	sampleSize := 3
 	sampleThreshold := 45
 	imo := NewCustom(sampleSize, sampleThreshold)
 
 	// empty file
-	ioutil.WriteFile(sampleFile, []byte{}, 0666)
+	os.WriteFile(sampleFile, []byte{}, 0666)
 	hash, err = imo.SumFile(sampleFile)
-	is.NotErr(err)
-	is.Equal(hash, [Size]byte{})
+	ok(t, err)
+	equal(t, hash, [Size]byte{})
 
 	// small file
-	ioutil.WriteFile(sampleFile, []byte("hello"), 0666)
+	os.WriteFile(sampleFile, []byte("hello"), 0666)
 	hash, err = imo.SumFile(sampleFile)
-	is.NotErr(err)
+	ok(t, err)
 
 	hashStr := fmt.Sprintf("%x", hash)
-	is.Equal(hashStr, "05d8a7b341bd9b025b1e906a48ae1d19")
+	equal(t, hashStr, "05d8a7b341bd9b025b1e906a48ae1d19")
 
 	/* boundary tests using the custom sample size */
 	size := sampleThreshold
 
 	// test that changing the gaps between sample zones does not affect the hash
 	data := bytes.Repeat([]byte{'A'}, size)
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h1, _ := imo.SumFile(sampleFile)
 
 	data[sampleSize] = 'B'
 	data[size-sampleSize-1] = 'B'
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h2, _ := imo.SumFile(sampleFile)
-	is.Equal(h1, h2)
+	equal(t, h1, h2)
 
 	// test that changing a byte on the edge (but within) a sample zone
 	// does change the hash
 	data = bytes.Repeat([]byte{'A'}, size)
 	data[sampleSize-1] = 'B'
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h3, _ := imo.SumFile(sampleFile)
-	is.NotEqual(h1, h3)
+	notEqual(t, h1, h3)
 
 	data = bytes.Repeat([]byte{'A'}, size)
 	data[size/2] = 'B'
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h4, _ := imo.SumFile(sampleFile)
-	is.NotEqual(h1, h4)
-	is.NotEqual(h3, h4)
+	notEqual(t, h1, h4)
+	notEqual(t, h3, h4)
 
 	data = bytes.Repeat([]byte{'A'}, size)
 	data[size/2+sampleSize-1] = 'B'
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h5, _ := imo.SumFile(sampleFile)
-	is.NotEqual(h1, h5)
-	is.NotEqual(h3, h5)
-	is.NotEqual(h4, h5)
+	notEqual(t, h1, h5)
+	notEqual(t, h3, h5)
+	notEqual(t, h4, h5)
 
 	data = bytes.Repeat([]byte{'A'}, size)
 	data[size-sampleSize] = 'B'
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h6, _ := imo.SumFile(sampleFile)
-	is.NotEqual(h1, h6)
-	is.NotEqual(h3, h6)
-	is.NotEqual(h4, h6)
-	is.NotEqual(h5, h6)
+	notEqual(t, h1, h6)
+	notEqual(t, h3, h6)
+	notEqual(t, h4, h6)
+	notEqual(t, h5, h6)
 
 	// test that changing the size changes the hash
 	data = bytes.Repeat([]byte{'A'}, size+1)
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	h7, _ := imo.SumFile(sampleFile)
-	is.NotEqual(h1, h7)
-	is.NotEqual(h3, h7)
-	is.NotEqual(h4, h7)
-	is.NotEqual(h5, h7)
-	is.NotEqual(h6, h7)
+	notEqual(t, h1, h7)
+	notEqual(t, h3, h7)
+	notEqual(t, h4, h7)
+	notEqual(t, h5, h7)
+	notEqual(t, h6, h7)
 
 	// test sampleSize < 1
 	imo = NewCustom(0, size)
 	data = bytes.Repeat([]byte{'A'}, size)
-	ioutil.WriteFile(sampleFile, data, 0666)
+	os.WriteFile(sampleFile, data, 0666)
 	hash, _ = imo.SumFile(sampleFile)
 	hashStr = fmt.Sprintf("%x", hash)
-	is.Equal(hashStr, "2d9123b54d37e9b8f94ab37a7eca6f40")
+	equal(t, hashStr, "2d9123b54d37e9b8f94ab37a7eca6f40")
 
 	os.Remove(sampleFile)
 }
@@ -122,16 +120,43 @@ func TestDefault(t *testing.T) {
 	var h1, h2 [Size]byte
 	var testData []byte
 
-	is := is.New(t)
-
 	for _, size := range []int{100, 131071, 131072, 50000} {
 		imo := NewCustom(16384, 131072)
 		testData = M(size)
-		is.Equal(Sum(testData), imo.Sum(testData))
-		ioutil.WriteFile(sampleFile, []byte{}, 0666)
+		equal(t, Sum(testData), imo.Sum(testData))
+		os.WriteFile(sampleFile, []byte{}, 0666)
 		h1, _ = SumFile(sampleFile)
 		h2, _ = imo.SumFile(sampleFile)
-		is.Equal(h1, h2)
+		equal(t, h1, h2)
 	}
 	os.Remove(sampleFile)
+}
+
+// Testing helpers from: https://github.com/benbjohnson/testing
+
+// ok fails the test if an err is not nil.
+func ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// equal fails the test if exp is not equal to act.
+func equal(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+}
+
+// equal fails the test if exp is equal to act.
+func notEqual(tb testing.TB, exp, act interface{}) {
+	if reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texpected mismatch, got matching\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, act)
+		tb.FailNow()
+	}
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -4,13 +4,10 @@ import (
 	"crypto/md5"
 	"fmt"
 	"testing"
-
-	"gopkg.in/tylerb/is.v1"
 )
 
 func TestSpec(t *testing.T) {
 	var hashStr string
-	is := is.New(t)
 
 	tests := []struct {
 		s    int
@@ -33,7 +30,7 @@ func TestSpec(t *testing.T) {
 	for _, test := range tests {
 		i := NewCustom(test.s, test.t)
 		hashStr = fmt.Sprintf("%x", i.Sum(M(test.n)))
-		is.Equal(hashStr, test.hash)
+		equal(t, hashStr, test.hash)
 	}
 }
 


### PR DESCRIPTION
Remove the now-archived 'is' library and replace it with simple helpers.