### PR TITLE
Change the name of the hashCore method to SumSectionReader so that it…

### DIFF
--- a/imohash.go
+++ b/imohash.go
@@ -59,11 +59,17 @@ func Sum(data []byte) [Size]byte {
 	return imo.Sum(data)
 }
 
+// SumSectionReader hashes a SectionReader using default sample parameters.
+func SumSectionReader(sr *io.SectionReader) ([Size]byte, error) {
+	imo := New()
+	return imo.SumSectionReader(sr)
+}
+
 // Sum hashes a byte slice using the ImoHash parameters.
 func (imo *ImoHash) Sum(data []byte) [Size]byte {
 	sr := io.NewSectionReader(bytes.NewReader(data), 0, int64(len(data)))
 
-	result, err := imo.hashCore(sr)
+	result, err := imo.SumSectionReader(sr)
 	if err != nil {
 		panic(err)
 	}
@@ -84,11 +90,11 @@ func (imo *ImoHash) SumFile(filename string) ([Size]byte, error) {
 		return emptyArray, err
 	}
 	sr := io.NewSectionReader(f, 0, fi.Size())
-	return imo.hashCore(sr)
+	return imo.SumSectionReader(sr)
 }
 
-// hashCore hashes a SectionReader using the ImoHash parameters.
-func (imo *ImoHash) hashCore(f *io.SectionReader) ([Size]byte, error) {
+// SumSectionReader hashes a SectionReader using the ImoHash parameters.
+func (imo *ImoHash) SumSectionReader(f *io.SectionReader) ([Size]byte, error) {
 	var result [Size]byte
 
 	imo.hasher.Reset()

--- a/imohash.go
+++ b/imohash.go
@@ -62,14 +62,14 @@ func Sum(data []byte) [Size]byte {
 // SumSectionReader hashes a SectionReader using default sample parameters.
 func SumSectionReader(sr *io.SectionReader) ([Size]byte, error) {
 	imo := New()
-	return imo.SumSectionReader(sr)
+	return imo.hashCore(sr)
 }
 
 // Sum hashes a byte slice using the ImoHash parameters.
 func (imo *ImoHash) Sum(data []byte) [Size]byte {
 	sr := io.NewSectionReader(bytes.NewReader(data), 0, int64(len(data)))
 
-	result, err := imo.SumSectionReader(sr)
+	result, err := imo.hashCore(sr)
 	if err != nil {
 		panic(err)
 	}
@@ -90,11 +90,16 @@ func (imo *ImoHash) SumFile(filename string) ([Size]byte, error) {
 		return emptyArray, err
 	}
 	sr := io.NewSectionReader(f, 0, fi.Size())
-	return imo.SumSectionReader(sr)
+	return imo.hashCore(sr)
 }
 
 // SumSectionReader hashes a SectionReader using the ImoHash parameters.
 func (imo *ImoHash) SumSectionReader(f *io.SectionReader) ([Size]byte, error) {
+	return imo.hashCore(f)
+}
+
+// hashCore hashes a SectionReader using the ImoHash parameters.
+func (imo *ImoHash) hashCore(f *io.SectionReader) ([Size]byte, error) {
 	var result [Size]byte
 
 	imo.hasher.Reset()


### PR DESCRIPTION
… can be used by external callers.

Thanks for the great repo. I'm hoping that you'd be willing to merge my pull request. I'm working with io.ReaderAt interfaces rather than files so I'd like to be able to use them directly. The intention of this change is to make that possible without breaking the current interface. If you have other ideas on how to go about it let me know.

Thanks!