### PR TITLE
Handle case when file size is too small for sample size

### DIFF
--- a/algorithm.md
+++ b/algorithm.md
@@ -19,25 +19,28 @@ This is done in two phases:
 
 imohash takes two parameters, as well as the message length:
 
-* sample size (s)
-* sampling threshold (t)
-* message length (L)
+- sample size (s)
+- sampling threshold (t)
+- message length (L)
 
-There are two mode of operation: **sampled** and **full**. Mode is
-determined as follows:
+There are two mode of operation: **sampled** and **full**.
+
+**Full** mode is a single hash of the entire message. While sampling is the key point of imohash, sometimes it doesn't make sense and a full hash is used. It is used when the message length is less than the sampling threshold, or is less than twice the sample size - 1 (in order to sample from the middle of the message). **Full** mode is also used when the sample size parameter is less than 1.
+
+In all other cases **sampled** mode is used. Summarized:
 
 ```
-if (s > 0) && (t > 0) && (L > t) && (t > 2s)
-  mode = sampled
-else
+if (s < 1) || (L < t) || (L < (2s - 1))
   mode = full
+else
+  mode = sampled
 ```
 
 ### Hash calculation
 
 The core hashing routine uses [MurmurHash3](https://code.google.com/p/smhasher/wiki/MurmurHash3) in a 128-bit configuration.
-Hashing in *Full* mode is identical to passing the entire
-message to Murmhash3.  *Sampled* mode constructs a new message using
+Hashing in **Full** mode is identical to passing the entire
+message to Murmhash3. **Sampled** mode constructs a new message using
 three samples from the original:
 
 Message M of length L is an array of bytes, M[0]...M[L-1]. If
@@ -51,6 +54,7 @@ S2 = M[L-s:L-1]
 
 h' = Murmur3(concat(S0, S1, S2))
 ```
+
 ### Size injection
 
 Size is inserted into the hash directly. This means that two files
@@ -119,8 +123,8 @@ threshold t.
 {16384, 131073, 131072, "808008282d3f3b53e1fd132cc51fcc1d"},
 {16384, 131072, 500000, "a0c21e44a0ba3bddee802a9d1c5332ca"},
 {50,    131072, 300000, "e0a712edd8815c606344aed13c44adcf"},
+{0,     100,    1000,  "e80753211a57ee0de67c756e98e00496"},
+{50,    9999,   1000,  "e80753211a57ee0de67c756e98e00496"},
+{501,   20,     1000,  "e80753211a57ee0de67c756e98e00496"},
+{501,   20,     1001,  "e9079899cffb46f60c8645a01f12f9c9"},
 ```
-
-
-
-

--- a/spec_test.go
+++ b/spec_test.go
@@ -25,12 +25,17 @@ func TestSpec(t *testing.T) {
 		{16384, 131073, 131072, "808008282d3f3b53e1fd132cc51fcc1d"},
 		{16384, 131072, 500000, "a0c21e44a0ba3bddee802a9d1c5332ca"},
 		{50, 131072, 300000, "e0a712edd8815c606344aed13c44adcf"},
+
+		{0, 100, 1000, "e80753211a57ee0de67c756e98e00496"},
+		{50, 9999, 1000, "e80753211a57ee0de67c756e98e00496"},
+		{501, 20, 1000, "e80753211a57ee0de67c756e98e00496"},
+		{501, 20, 1001, "e9079899cffb46f60c8645a01f12f9c9"},
 	}
 
 	for _, test := range tests {
 		i := NewCustom(test.s, test.t)
 		hashStr = fmt.Sprintf("%x", i.Sum(M(test.n)))
-		equal(t, hashStr, test.hash)
+		equal(t, test.hash, hashStr)
 	}
 }
 


### PR DESCRIPTION
# Issue

Behavior can be unpredictable if the file size is less than ~2x the sample size and sampling is used. This could include hash values that differ between imohash implementations, or even crashing (see #15).

# Affected Users

This affects users who:
* Set custom parameters
* Have the `sample_size` > `2*sample_threshold`
* Are processing files in the size range: `sample_threshold` --> `2*sample_size`

# Analysis
imohash samples at the beginning, middle, and end of the file. If the sample size is `s` , the file needs to be at least `2s-1` to sample the middle without hitting EOF. Furthermore, if `s` is larger than the whole file, then there can be a seek() error when trying to sample `s` back from the end of the file.

The original spec didn't correctly address this. There is a check described relating the sample size and sample threshold, but it doesn't really make sense. What matters is the actual file size and the sample size. Furthermore, the check was never implemented anyway! 

Since the default sample size is 0.125 of the default threshold, the problem condition is never hit when using defaults. 

# Fix 
The spec and code have been updated to check for sample size relative to file size and choose the correct mode.

If you're using custom parameters in the range described above and saving the hash, the hash post-upgrade will differ for files within the affected size range. In practice, this is a rare case. Most uses are for synchronization, and the hashes are ephemeral. Technically, this is a breaking change. However, given the narrow nature of this issue, I'm merely going to v1.1.0 with it and not a full v2.

Fixes #15 