### PR TITLE
imosum: add support for directories

### DIFF
--- a/cmd/imosum/main.go
+++ b/cmd/imosum/main.go
@@ -32,7 +32,9 @@ func walkDirFunction(path string, dirEntry fs.DirEntry, err error) error {
 }
 
 func processDir(path string) {
-	filepath.WalkDir(path, walkDirFunction)
+	if err := filepath.WalkDir(path, walkDirFunction); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func main() {


### PR DESCRIPTION
Improve the imosum tool to print hashes for all files contained in directories. This allows to quickly verify a recursive copy, e.g. with cp, copy, rsync, robocopy...